### PR TITLE
add support for h0neytr4p v0.4

### DIFF
--- a/honeypots/h0neytr4p.py
+++ b/honeypots/h0neytr4p.py
@@ -1,8 +1,65 @@
-# honeypots/h0neytr4p.py
-
+from datetime import datetime
+from urllib import parse
+import os
 import time
 from modules.ealert import EAlert
-from datetime import datetime
+
+
+def _format_timezone(offset):
+    seconds = int(offset.total_seconds())
+    sign = '+' if seconds >= 0 else '-'
+    seconds = abs(seconds)
+    hours, seconds = divmod(seconds, 3600)
+    minutes = seconds // 60
+    return f"{sign}{hours:02d}{minutes:02d}"
+
+
+def _parse_timestamp(timestamp):
+    dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+
+    if dt.tzinfo is not None and dt.utcoffset() is not None:
+        timezone = _format_timezone(dt.utcoffset())
+    else:
+        timezone = time.strftime('%z')
+
+    return dt.strftime('%Y-%m-%d %H:%M:%S'), timezone
+
+
+def _payload_path(line, payloaddir):
+    payload_filename = line.get('payload_filename')
+    payload_hash = line.get('payload_hash_md5')
+    candidates = []
+
+    if payload_filename:
+        if os.path.isabs(payload_filename):
+            candidates.append(payload_filename)
+        elif payloaddir:
+            candidates.append(os.path.join(payloaddir, payload_filename))
+
+    if payloaddir and payload_filename:
+        candidates.append(os.path.join(payloaddir, os.path.basename(payload_filename)))
+
+    if payloaddir and payload_hash:
+        candidates.append(os.path.join(payloaddir, payload_hash))
+
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+
+    return candidates[0] if candidates else None
+
+
+def _add_metadata(alert, line, keys):
+    for key in keys:
+        if key in line:
+            alert.adata(key, line[key])
+
+
+def _add_prefixed_metadata(alert, line, prefixes):
+    for key, value in line.items():
+        if key.startswith(prefixes):
+            alert.adata(key, value)
+
 
 def h0neytr4p(ECFG):
     h0neytr4p = EAlert('h0neytr4p', ECFG)
@@ -21,30 +78,58 @@ def h0neytr4p(ECFG):
             break
         if line == 'jsonfail':
             continue
-        
+
         h0neytr4p.data('analyzer_id', HONEYPOT['nodeid']) if 'nodeid' in HONEYPOT else None
 
-        h0neytr4p.data('timestamp', datetime.fromisoformat(line['timestamp']).strftime('%Y-%m-%d %H:%M:%S'))
-        h0neytr4p.data("timezone", time.strftime('%z'))
+        if 'timestamp' in line:
+            timestamp, timezone = _parse_timestamp(line['timestamp'])
+            h0neytr4p.data('timestamp', timestamp)
+            h0neytr4p.data("timezone", timezone)
 
         h0neytr4p.data('source_address', line['src_ip'] ) if 'src_ip' in line else None
         h0neytr4p.data('target_address', ECFG['ip_ext'])
-        h0neytr4p.data('source_port', '0') # No source_port in logs :-( 
+        h0neytr4p.data('source_port', '0') # No source_port in logs :-(
         h0neytr4p.data('target_port', line['dest_port'] ) if 'dest_port' in line else None
         h0neytr4p.data('source_protocol', "tcp")
         h0neytr4p.data('target_protocol', "tcp")
 
         h0neytr4p.request("description", "H0neytr4p Honeypot")
+        h0neytr4p.request("url", parse.quote(str(line['request_uri']).encode('ascii', 'ignore'))) if 'request_uri' in line else None
 
-        h0neytr4p.adata('user-agent', line['user-agent']) if 'user-agent' in line else None
-        h0neytr4p.adata('user-agent_browser', line['user-agent_browser']) if 'user-agent_browser' in line else None
-        h0neytr4p.adata('user-agent_browser_version', line['user-agent_browser_version']) if 'user-agent_browser_version' in line else None
-        h0neytr4p.adata('user-agent_os', line['user-agent_os']) if 'user-agent_os' in line else None
-        
-        h0neytr4p.adata('trapped', line['trapped']) if 'trapped' in line else None
-        h0neytr4p.adata('trapped_for', line['trapped_for']) if 'trapped_for' in line else None
-        h0neytr4p.adata('request_uri', line['request_uri']) if 'request_uri' in line else None
-        
+        if 'request_method' in line:
+            h0neytr4p.adata('httpmethod', line['request_method'])
+
+        _add_metadata(h0neytr4p, line, [
+            'protocol',
+            'hostname',
+            'request_proto',
+            'request_uri',
+            'user-agent',
+            'user-agent_browser',
+            'user-agent_browser_version',
+            'user-agent_os',
+            'trapped',
+            'trapped_for',
+            'trapped_references',
+            'trapped_risk_rating',
+        ])
+        _add_prefixed_metadata(h0neytr4p, line, ('header_', 'cookie_', 'payload_'))
+
+        if ECFG['send_malware'] is True and ('payload_filename' in line or 'payload_hash_md5' in line):
+            payload_path = _payload_path(line, HONEYPOT.get('payloaddir'))
+            if payload_path:
+                payload_md5 = line.get('payload_hash_md5') or os.path.basename(payload_path)
+                error, payload = h0neytr4p.malwarecheck(
+                    os.path.dirname(payload_path),
+                    os.path.basename(payload_path),
+                    ECFG['del_malware_after_send'],
+                    payload_md5
+                )
+                if (error is True) and (len(payload) <= 5 * 1024) and (len(payload) > 0):
+                    h0neytr4p.request('binary', payload.decode('utf-8'))
+                elif (error is True) and (len(payload) > 0):
+                    h0neytr4p.request('largepayload', payload.decode('utf-8'))
+
         h0neytr4p.adata('externalIP', ECFG['ip_ext'])
         h0neytr4p.adata('internalIP', ECFG['ip_int'])
         h0neytr4p.adata('uuid', ECFG['uuid'])
@@ -53,4 +138,4 @@ def h0neytr4p(ECFG):
             break
 
     h0neytr4p.finAlert()
-    return()            
+    return()


### PR DESCRIPTION
@trixam @elivlo Please review and test (updated images for h0neytr4p have been pushed).

Here are testing logs:
```
{"dest_port":"8443","header_accept":"*/*","header_content-length":"419","header_content-type":"multipart/form-data","header_user-agent":"curl/8.14.1","hostname":"127.0.0.1","payload_filename":"/data/h0neytr4p/payloads/16318505ade01496c9f7b8c874899134","payload_hash_md5":"16318505ade01496c9f7b8c874899134","payload_mime_type":"text/plain","payload_parameter":"marker=payload-test-1780936857","protocol":"https","request_method":"POST","request_proto":"HTTP/2.0","request_uri":"/vpns/portal/scripts/newbm.pl","src_ip":"172.22.0.1","timestamp":"2026-06-08T16:40:57Z","trapped":"true","trapped_for":"CVE-2019-19781","trapped_references":"https://www.kb.cert.org/vuls/id/619785","trapped_risk_rating":"9.8","user-agent":"curl/8.14.1","user-agent_browser":"curl","user-agent_browser_version":"8.14","user-agent_os":"Other"}
{"dest_port":"8443","header_accept":"*/*","header_user-agent":"curl/8.14.1","header_x-h0neytr4p-test":"cve-2026-23918-test-1780936950","hostname":"127.0.0.1","protocol":"https","request_method":"GET","request_proto":"HTTP/2.0","request_uri":"/?h0neytr4p_test=cve-2026-23918-test-1780936950","src_ip":"172.22.0.1","timestamp":"2026-06-08T16:42:30Z","trapped":"true","trapped_for":"CVE-2026-23918","trapped_references":"https://httpd.apache.org/security/vulnerabilities_24.html,https://www.openwall.com/lists/oss-security/2026/05/04/19,https://www.cve.org/CVERecord?id=CVE-2026-23918,https://orca.security/resources/blog/apache-http-server-http2-vulnerability-cve-2026-23918/","trapped_risk_rating":"8.8","user-agent":"curl/8.14.1","user-agent_browser":"curl","user-agent_browser_version":"8.14","user-agent_os":"Other"}
{"cookie_whostmgrsession":"cve-2026-41940-test-1780936963","dest_port":"2087","header_accept":"*/*","header_authorization":"Basic aDBuZXl0cjRwLXRlc3Q6c3ludGhldGljCnN1Y2Nlc3NmdWxfaW50ZXJuYWxfYXV0aF93aXRoX3RpbWVzdGFtcD10ZXN0LWN2ZS0yMDI2LTQxOTQwLXRlc3QtMTc4MDkzNjk2Mw==","header_cookie":"whostmgrsession=cve-2026-41940-test-1780936963","header_user-agent":"curl/8.14.1","header_x-h0neytr4p-test":"cve-2026-41940-test-1780936963","hostname":"127.0.0.1","protocol":"https","request_method":"POST","request_proto":"HTTP/2.0","request_uri":"/login/?login_only=1\u0026h0neytr4p_test=cve-2026-41940-test-1780936963","src_ip":"172.22.0.1","timestamp":"2026-06-08T16:42:43Z","trapped":"true","trapped_for":"CVE-2026-41940","trapped_references":"https://www.cpanel.net/blog/security/security-update-cve-2026-41940/,https://www.cve.org/CVERecord?id=CVE-2026-41940,https://www.rapid7.com/db/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce/","trapped_risk_rating":"9.8","user-agent":"curl/8.14.1","user-agent_browser":"curl","user-agent_browser_version":"8.14","user-agent_os":"Other"}
{"cookie_whostmgrsession":"cve-2026-41940-test-1780936963-negative","dest_port":"2087","header_accept":"*/*","header_authorization":"Basic YWRtaW46YWRtaW4=","header_cookie":"whostmgrsession=cve-2026-41940-test-1780936963-negative","header_user-agent":"curl/8.14.1","header_x-h0neytr4p-test":"cve-2026-41940-test-1780936963-negative","hostname":"127.0.0.1","protocol":"https","request_method":"POST","request_proto":"HTTP/2.0","request_uri":"/login/?login_only=1\u0026h0neytr4p_test=cve-2026-41940-test-1780936963-negative","src_ip":"172.22.0.1","timestamp":"2026-06-08T16:42:43Z","trapped":"false","user-agent":"curl/8.14.1","user-agent_browser":"curl","user-agent_browser_version":"8.14","user-agent_os":"Other"}
```