### PR TITLE
feat(mailoney): support next JSONL format with malwaredir storage

### DIFF
--- a/ews.cfg.default
+++ b/ews.cfg.default
@@ -188,7 +188,8 @@ logfile = /opt/log4pot/log/log4pot.log
 [MAILONEY]
 mailoney = false
 nodeid = <your unique analyzer id>
-logfile = /opt/mailoney/commands.log
+logfile = /opt/mailoney/log/log.json
+malwaredir = /opt/mailoney/log/mails
 
 [MEDPOT]
 medpot = false

--- a/ews.cfg.docker
+++ b/ews.cfg.docker
@@ -188,7 +188,8 @@ logfile = /data/log4pot/log/log4pot.log
 [MAILONEY]
 mailoney = true
 nodeid = mailoney-community-01
-logfile = /data/mailoney/log/commands.log
+logfile = /data/mailoney/log/log.json
+malwaredir = /data/mailoney/log/mails
 
 [MEDPOT]
 medpot = true

--- a/honeypots/mailoney.py
+++ b/honeypots/mailoney.py
@@ -1,13 +1,192 @@
 # honeypots/mailoney.py
 
+import base64
+import json
 import time
-from modules.ealert import EAlert
+from datetime import datetime
+from pathlib import Path
+
+
+SKIP_EVENT_TYPES = ("rate_limit_block",)
+MAX_PAYLOAD_SIZE = 10 * 1024 * 1024
+SMALL_PAYLOAD_SIZE = 5 * 1024
+
+
+def _parse_timestamp(value):
+    if not value:
+        return(None, None)
+
+    timestamp = str(value)
+    try:
+        if timestamp.endswith("Z"):
+            timestamp = timestamp[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(timestamp)
+    except ValueError:
+        return(f"{str(value)[0:10]} {str(value)[11:19]}", time.strftime('%z'))
+
+    timezone = parsed.strftime('%z') or time.strftime('%z')
+    return(parsed.strftime('%Y-%m-%d %H:%M:%S'), timezone)
+
+
+def _compact_value(value):
+    if isinstance(value, (dict, list)):
+        return(json.dumps(value, ensure_ascii=False, separators=(',', ':')))
+    return(value)
+
+
+def _is_empty(value):
+    return(value is None or value == "" or value == [] or value == {})
+
+
+def _event_additional_data(line):
+    adata = {}
+
+    for key, value in line.items():
+        if _is_empty(value):
+            continue
+        adata[key] = _compact_value(value)
+
+    return(adata)
+
+
+def _event_file_refs(line):
+    refs = []
+
+    if line.get('mail.eml_file'):
+        refs.append((line['mail.eml_file'], f"mailoney:eml:{line['mail.eml_file']}"))
+
+    attachment_files = line.get('attachment.files', [])
+    attachment_hashes = line.get('attachment.sha256', [])
+
+    if isinstance(attachment_files, str):
+        attachment_files = [attachment_files]
+    if isinstance(attachment_hashes, str):
+        attachment_hashes = [attachment_hashes]
+    if not isinstance(attachment_files, list):
+        return(refs)
+
+    for index, attachment in enumerate(attachment_files):
+        if not attachment:
+            continue
+
+        if isinstance(attachment_hashes, list) and index < len(attachment_hashes) and attachment_hashes[index]:
+            checksum = attachment_hashes[index]
+        else:
+            checksum = attachment
+
+        refs.append((attachment, f"mailoney:attachment:{checksum}"))
+
+    return(refs)
+
+
+def _resolve_malware_path(malwaredir, filename):
+    if not malwaredir or not filename:
+        return(None)
+
+    base = Path(malwaredir).resolve()
+    candidate = Path(str(filename))
+
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+    else:
+        resolved = (base / candidate).resolve()
+
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        return(None)
+
+    return(resolved)
+
+
+def _attach_payload(alert, malwaredir, filename, checksum, remove_after_send=False):
+    payload_file = _resolve_malware_path(malwaredir, filename)
+
+    if payload_file is None:
+        alert.logger.warning(f"Mailoney storage path {filename} is outside malwaredir {malwaredir}. Not send.", '2')
+        return(False)
+
+    if not payload_file.is_file():
+        alert.logger.warning(f"Mailoney storage file {payload_file} does not exist. Not send.", '2')
+        return(False)
+
+    if payload_file.stat().st_size > MAX_PAYLOAD_SIZE:
+        alert.logger.warning(f"Mailoney storage file {payload_file} is bigger than 10 MB. Not send.", '2')
+        return(False)
+
+    if alert.md5malware(checksum) is False:
+        alert.logger.warning(f"Mailoney storage file {checksum} already submitted.", '2')
+        return(False)
+
+    payload = base64.b64encode(payload_file.read_bytes())
+    if remove_after_send is True:
+        payload_file.unlink()
+
+    if len(payload) <= SMALL_PAYLOAD_SIZE and len(payload) > 0:
+        alert.request('binary', payload.decode('utf-8'))
+    elif len(payload) > 0:
+        alert.request('largepayload', payload.decode('utf-8'))
+
+    return(True)
+
+
+def _attach_event_payloads(alert, line, HONEYPOT, ECFG):
+    if ECFG.get('send_malware') is not True:
+        return(False)
+
+    for filename, checksum in _event_file_refs(line):
+        _attach_payload(alert, HONEYPOT.get('malwaredir'), filename, checksum, ECFG.get('del_malware_after_send', False))
+
+    return(True)
+
+
+def _build_event(line, HONEYPOT, ECFG):
+    if line.get('event.type') in SKIP_EVENT_TYPES:
+        return(None)
+    if not line.get('timestamp') or not line.get('src_ip'):
+        return(None)
+
+    timestamp, timezone = _parse_timestamp(line.get('timestamp'))
+    if timestamp is None:
+        return(None)
+
+    target_port = line.get('dest_port') or line.get('listener.port') or 25
+    event_type = line.get('event.type', 'unknown')
+
+    event = {
+        'data': {
+            'timestamp': timestamp,
+            'timezone': timezone,
+            'source_address': line.get('src_ip'),
+            'target_address': line.get('dest_ip') or ECFG['ip_ext'],
+            'source_port': str(line.get('src_port', 0)),
+            'target_port': str(target_port),
+            'source_protocol': 'tcp',
+            'target_protocol': 'tcp',
+        },
+        'request': {
+            'description': f"Mail Honeypot mailoney ({event_type})",
+        },
+        'adata': _event_additional_data(line),
+    }
+
+    if HONEYPOT.get('nodeid'):
+        event['data']['analyzer_id'] = HONEYPOT['nodeid']
+
+    event['adata']['hostname'] = ECFG['hostname']
+    event['adata']['externalIP'] = ECFG['ip_ext']
+    event['adata']['internalIP'] = ECFG['ip_int']
+    event['adata']['uuid'] = ECFG['uuid']
+
+    return(event)
 
 
 def mailoney(ECFG):
+    from modules.ealert import EAlert
+
     mailoney = EAlert('mailoney', ECFG)
 
-    ITEMS = ['mailoney', 'nodeid', 'logfile']
+    ITEMS = ['mailoney', 'nodeid', 'logfile', 'malwaredir']
     HONEYPOT = (mailoney.readCFG(ITEMS, ECFG['cfgfile']))
 
     if HONEYPOT.get('mailoney').lower() == "false":
@@ -21,27 +200,19 @@ def mailoney(ECFG):
             break
         if line == 'jsonfail':
             continue
-        if 'EHLO User' not in line['data']:
+
+        event = _build_event(line, HONEYPOT, ECFG)
+        if event is None:
             continue
 
-        mailoney.data('analyzer_id', HONEYPOT['nodeid']) if 'nodeid' in HONEYPOT else None
+        for key, value in event['data'].items():
+            mailoney.data(key, value)
+        for key, value in event['request'].items():
+            mailoney.request(key, value)
+        for key, value in event['adata'].items():
+            mailoney.adata(key, value)
 
-        mailoney.data('timestamp', f"{line['timestamp'][0:10]} {line['timestamp'][11:19]}")
-        mailoney.data("timezone", time.strftime('%z'))
-
-        mailoney.data('source_address', line['src_ip']) if 'src_ip' in line else None
-        mailoney.data('target_address', ECFG['ip_ext'])
-        mailoney.data('source_port', str(line['src_port'])) if 'src_port' in line else None
-        mailoney.data('target_port', "25")
-        mailoney.data('source_protocol', "tcp")
-        mailoney.data('target_protocol', "tcp")
-
-        mailoney.request("description", "Mail Honeypot mailoney")
-
-        mailoney.adata('hostname', ECFG['hostname'])
-        mailoney.adata('externalIP', ECFG['ip_ext'])
-        mailoney.adata('internalIP', ECFG['ip_int'])
-        mailoney.adata('uuid', ECFG['uuid'])
+        _attach_event_payloads(mailoney, line, HONEYPOT, ECFG)
 
         if mailoney.buildAlert() == "sendlimit":
             break

--- a/modules/ealert.py
+++ b/modules/ealert.py
@@ -265,7 +265,12 @@ class EAlert:
         keywords = ("description", 'url', 'binary', 'request', 'raw', 'payload', 'largepayload')
 
         if key in keywords:
-            self.REQUEST[key] = value
+            if key in self.REQUEST:
+                if not isinstance(self.REQUEST[key], list):
+                    self.REQUEST[key] = [self.REQUEST[key]]
+                self.REQUEST[key].append(value)
+            else:
+                self.REQUEST[key] = value
         else:
             self.logger.error(f"Unknow keyword in request {key} = {value}.", '1E')
             return(False)
@@ -294,7 +299,11 @@ class EAlert:
             etree.SubElement(Alert, "Classification", origin=self.DATA["corigin"], ident=self.DATA["cident"], text=self.DATA["ctext"])
 
         for key, value in list(self.REQUEST.items()):
-            etree.SubElement(Alert, "Request", type=key).text = value
+            if isinstance(value, list):
+                for item in value:
+                    etree.SubElement(Alert, "Request", type=key).text = item
+            else:
+                etree.SubElement(Alert, "Request", type=key).text = value
 
         for key, value in list(self.ADATA.items()):
             if isinstance(value, int):
@@ -365,7 +374,11 @@ class EAlert:
         print(f'-- REQUEST ----------------------------------')
 
         for key, value in list(self.REQUEST.items()):
-            print(f'{key} : {value}')
+            if isinstance(value, list):
+                for item in value:
+                    print(f'{key} : {item}')
+            else:
+                print(f'{key} : {value}')
 
         print(f'-- ADATA ------------------------------------')
 

--- a/tests/test_mailoney.py
+++ b/tests/test_mailoney.py
@@ -1,0 +1,174 @@
+import base64
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "mailoney_module",
+    ROOT / "honeypots" / "mailoney.py",
+)
+mailoney = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mailoney)
+
+
+ECFG = {
+    "hostname": "ews-host",
+    "ip_ext": "198.51.100.10",
+    "ip_int": "10.0.0.10",
+    "uuid": "test-uuid",
+    "send_malware": False,
+    "del_malware_after_send": False,
+}
+
+HONEYPOT = {
+    "nodeid": "mailoney-node",
+    "malwaredir": "/tmp/mailoney/log/mails",
+}
+
+
+class FakeLogger:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, message, handles=''):
+        self.warnings.append((message, handles))
+
+
+class FakeAlert:
+    def __init__(self):
+        self.logger = FakeLogger()
+        self.requests = []
+        self.submitted = set()
+
+    def md5malware(self, checksum):
+        if checksum in self.submitted:
+            return(False)
+        self.submitted.add(checksum)
+        return(True)
+
+    def request(self, key, value):
+        self.requests.append((key, value))
+        return(True)
+
+
+class MailoneyEventTests(unittest.TestCase):
+    def test_rate_limit_events_are_skipped(self):
+        line = {
+            "event.type": "rate_limit_block",
+            "timestamp": "2026-06-15T16:18:25.123Z",
+            "src_ip": "203.0.113.7",
+        }
+
+        self.assertIsNone(mailoney._build_event(line, HONEYPOT, ECFG))
+
+    def test_mail_auth_and_session_events_are_mapped(self):
+        for event_type in ("mail", "auth", "session"):
+            with self.subTest(event_type=event_type):
+                line = {
+                    "event.type": event_type,
+                    "timestamp": "2026-06-15T16:18:25.123Z",
+                    "src_ip": "203.0.113.7",
+                    "src_port": 54321,
+                    "dest_ip": "198.51.100.20",
+                    "listener.port": 587,
+                    "mail.envelope_to": ["bob@example.test"],
+                    "tls.used": False,
+                    "attachment.count": 0,
+                    "nested": {"a": 1},
+                }
+
+                event = mailoney._build_event(line, HONEYPOT, ECFG)
+
+                self.assertEqual(event["data"]["analyzer_id"], "mailoney-node")
+                self.assertEqual(event["data"]["timestamp"], "2026-06-15 16:18:25")
+                self.assertEqual(event["data"]["timezone"], "+0000")
+                self.assertEqual(event["data"]["source_address"], "203.0.113.7")
+                self.assertEqual(event["data"]["source_port"], "54321")
+                self.assertEqual(event["data"]["target_address"], "198.51.100.20")
+                self.assertEqual(event["data"]["target_port"], "587")
+                self.assertEqual(event["request"]["description"], f"Mail Honeypot mailoney ({event_type})")
+                self.assertEqual(event["adata"]["mail.envelope_to"], '["bob@example.test"]')
+                self.assertEqual(event["adata"]["nested"], '{"a":1}')
+                self.assertIs(event["adata"]["tls.used"], False)
+                self.assertEqual(event["adata"]["attachment.count"], 0)
+
+    def test_dest_port_overrides_listener_port_and_missing_dest_ip_uses_external_ip(self):
+        line = {
+            "event.type": "mail",
+            "timestamp": "2026-06-15T16:18:25Z",
+            "src_ip": "203.0.113.7",
+            "src_port": 54321,
+            "dest_port": 2525,
+            "listener.port": 587,
+        }
+
+        event = mailoney._build_event(line, HONEYPOT, ECFG)
+
+        self.assertEqual(event["data"]["target_address"], "198.51.100.10")
+        self.assertEqual(event["data"]["target_port"], "2525")
+
+    def test_payload_files_are_not_read_when_send_malware_is_false(self):
+        alert = FakeAlert()
+        line = {
+            "mail.eml_file": "2026-06-15/203.0.113.7/session/message.eml",
+            "attachment.files": ["2026-06-15/203.0.113.7/session/attachments/a.bin"],
+            "attachment.sha256": ["attachment-sha"],
+        }
+
+        mailoney._attach_event_payloads(alert, line, HONEYPOT, ECFG)
+
+        self.assertEqual(alert.requests, [])
+        self.assertEqual(alert.submitted, set())
+
+    def test_payload_files_are_attached_from_malwaredir_when_enabled(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            malwaredir = Path(tmpdir) / "mails"
+            eml = malwaredir / "2026-06-15" / "203.0.113.7" / "session" / "message.eml"
+            attachment = eml.parent / "attachments" / "a.bin"
+            eml.parent.mkdir(parents=True)
+            attachment.parent.mkdir(parents=True)
+            eml.write_bytes(b"Subject: hello\r\n\r\nBody")
+            attachment.write_bytes(b"sample")
+
+            alert = FakeAlert()
+            hcfg = {"malwaredir": str(malwaredir)}
+            ecfg = dict(ECFG, send_malware=True)
+            line = {
+                "mail.eml_file": "2026-06-15/203.0.113.7/session/message.eml",
+                "attachment.files": ["2026-06-15/203.0.113.7/session/attachments/a.bin"],
+                "attachment.sha256": ["attachment-sha"],
+            }
+
+            mailoney._attach_event_payloads(alert, line, hcfg, ecfg)
+
+            self.assertEqual(len(alert.requests), 2)
+            self.assertEqual(alert.requests[0][0], "binary")
+            self.assertEqual(alert.requests[0][1], base64.b64encode(eml.read_bytes()).decode("utf-8"))
+            self.assertEqual(alert.requests[1][0], "binary")
+            self.assertEqual(alert.requests[1][1], base64.b64encode(attachment.read_bytes()).decode("utf-8"))
+            self.assertEqual(
+                alert.submitted,
+                {
+                    "mailoney:eml:2026-06-15/203.0.113.7/session/message.eml",
+                    "mailoney:attachment:attachment-sha",
+                },
+            )
+
+    def test_payload_path_must_stay_inside_malwaredir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alert = FakeAlert()
+            hcfg = {"malwaredir": str(Path(tmpdir) / "mails")}
+            ecfg = dict(ECFG, send_malware=True)
+            line = {"mail.eml_file": "../outside.eml"}
+
+            mailoney._attach_event_payloads(alert, line, hcfg, ecfg)
+
+            self.assertEqual(alert.requests, [])
+            self.assertEqual(len(alert.logger.warnings), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@trixam @elivlo - Please review and test.

## Summary
- add support for the upcoming Mailoney `next` version JSONL event format
- switch Mailoney config examples from legacy `commands.log` to `log/log.json`
- use `[MAILONEY] malwaredir` for Mailoney stored `.eml` files and attachments
- preserve non-rate-limit Mailoney JSON fields as EWS AdditionalData
- send stored mails/attachments only when `send_malware = true`

## Mailoney Reference
This targets the new Mailoney version currently available on the `next` branch:
https://github.com/t3chn0m4g3/mailoney/tree/next

That version replaces the old command-style log with flat JSONL events for
`mail`, `auth`, `session`, and `rate_limit_block`, and stores captured mail data
under its configured storage directory.

## Tests
- `python3 -m compileall honeypots/mailoney.py modules/ealert.py`
- `python3 -m unittest discover -s tests`