### PR TITLE
Update RedisHoneyPot parser for next branch schema

### DIFF
--- a/honeypots/redishoneypot.py
+++ b/honeypots/redishoneypot.py
@@ -4,6 +4,81 @@ import time
 from modules.ealert import EAlert
 from datetime import datetime
 
+
+EWS_CORE_FIELDS = {
+    'timestamp', 'network', 'src_ip', 'src_port', 'dest_ip', 'dest_port',
+}
+
+LOG_ENVELOPE_FIELDS = {
+    'level', 'message', 'event',
+}
+
+REDIS_METADATA_FIELDS = (
+    'protocol', 'profile',
+    'session_id', 'client_id', 'session_start', 'session_end',
+    'session_duration', 'session_duration_ms',
+    'client_name', 'client_library_name', 'client_library_version',
+    'user_agent',
+    'redis_db', 'command', 'command_category', 'arg_count',
+    'response_class', 'response_bytes', 'outcome', 'close_after_command',
+    'args_text', 'args_truncated', 'args_sha256',
+    'analysis_hint',
+    'key', 'key_count', 'key_pattern', 'value_size', 'value_sha256',
+    'config_subcommand', 'config_key', 'config_value',
+    'config_value_truncated', 'config_value_sha256',
+    'replica_host', 'replica_port',
+    'replconf_key', 'replconf_value',
+    'module_subcommand', 'module_path',
+    'auth_username', 'auth_password_length', 'auth_password_sha256',
+    'client_subcommand',
+    'error', 'max_bulk_bytes', 'max_inline_bytes', 'max_array_elems',
+)
+
+
+def _is_metadata_value(value):
+    return value is not None and isinstance(value, (str, int, float, bool))
+
+
+def _format_timestamp(value):
+    if not value:
+        return None
+
+    if isinstance(value, str) and value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+
+    try:
+        return datetime.fromisoformat(str(value)).strftime('%Y-%m-%d %H:%M:%S')
+    except ValueError:
+        return None
+
+
+def _request_text(line):
+    command = line.get('command')
+
+    if command and line.get('args_text'):
+        return f"{command} {line['args_text']}"
+    if command:
+        return str(command)
+
+    return 'Redis command'
+
+
+def _add_redis_metadata(alert, line):
+    added = set()
+
+    for key in REDIS_METADATA_FIELDS:
+        value = line.get(key)
+        if _is_metadata_value(value):
+            alert.adata(key, value)
+            added.add(key)
+
+    for key, value in line.items():
+        if key in added or key in EWS_CORE_FIELDS or key in LOG_ENVELOPE_FIELDS:
+            continue
+        if _is_metadata_value(value):
+            alert.adata(key, value)
+
+
 def redishoneypot(ECFG):
     redishoneypot = EAlert('redishoneypot', ECFG)
 
@@ -21,24 +96,38 @@ def redishoneypot(ECFG):
             break
         if line == 'jsonfail':
             continue
-        if line['action'] != "NewConnect":
+        if not isinstance(line, dict):
+            continue
+        if line.get('event') != 'command':
+            continue
+
+        timestamp = _format_timestamp(line.get('timestamp'))
+        source_address = line.get('src_ip')
+        source_port = line.get('src_port')
+
+        if not timestamp or not source_address or source_port is None:
             continue
 
         redishoneypot.data('analyzer_id', HONEYPOT['nodeid']) if 'nodeid' in HONEYPOT else None
 
-        if 'time' in line:
-            redishoneypot.data('timestamp', datetime.fromisoformat(line['time']).strftime('%Y-%m-%d %H:%M:%S'))
-            redishoneypot.data("timezone", time.strftime('%z'))
+        redishoneypot.data('timestamp', timestamp)
+        redishoneypot.data('timezone', time.strftime('%z'))
 
-        redishoneypot.data('source_address', line['addr'].split(':')[0]) if 'addr' in line else None
-        redishoneypot.data('target_address', ECFG['ip_ext'])
-        redishoneypot.data('source_port', line['addr'].split(':')[1]) if 'addr' in line else None
-        redishoneypot.data('target_port', '6379')
-        redishoneypot.data('source_protocol', 'tcp')
-        redishoneypot.data('target_protocol', 'tcp')
+        target_address = line.get('dest_ip') or ECFG['ip_ext']
+        target_port = line.get('dest_port') or '6379'
+        network = line.get('network') or 'tcp'
+
+        redishoneypot.data('source_address', source_address)
+        redishoneypot.data('target_address', target_address)
+        redishoneypot.data('source_port', str(source_port))
+        redishoneypot.data('target_port', str(target_port))
+        redishoneypot.data('source_protocol', network)
+        redishoneypot.data('target_protocol', network)
 
         redishoneypot.request('description', 'Redis Honeypot')
+        redishoneypot.request('request', _request_text(line))
 
+        _add_redis_metadata(redishoneypot, line)
         redishoneypot.adata('hostname', ECFG['hostname'])
         redishoneypot.adata('externalIP', ECFG['ip_ext'])
         redishoneypot.adata('internalIP', ECFG['ip_int'])

--- a/tests/test_redishoneypot.py
+++ b/tests/test_redishoneypot.py
@@ -1,0 +1,256 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class FakeEAlert:
+    instances = []
+
+    def __init__(self, modul, ecfg):
+        self.modul = modul
+        self.ecfg = ecfg
+        self.lines = list(ecfg['test_lines'])
+        self.data_values = {}
+        self.request_values = {}
+        self.additional_data = {}
+        self.alerts = []
+        self.finished = False
+        FakeEAlert.instances.append(self)
+
+    def readCFG(self, items, cfgfile):
+        return {
+            'redishoneypot': 'true',
+            'nodeid': 'redishoneypot-test',
+            'logfile': '/tmp/redishoneypot.log',
+        }
+
+    def lineREAD(self, filename, line_format):
+        if not self.lines:
+            return ()
+        return self.lines.pop(0)
+
+    def data(self, key, value):
+        self.data_values[key] = value
+
+    def request(self, key, value):
+        self.request_values[key] = value
+
+    def adata(self, key, value):
+        self.additional_data[key] = value
+
+    def buildAlert(self):
+        self.alerts.append({
+            'data': self.data_values.copy(),
+            'request': self.request_values.copy(),
+            'additionaldata': self.additional_data.copy(),
+        })
+        self.data_values.clear()
+        self.request_values.clear()
+        self.additional_data.clear()
+        return True
+
+    def finAlert(self):
+        self.finished = True
+
+
+def load_redishoneypot_module(monkeypatch):
+    fake_modules = types.ModuleType('modules')
+    fake_modules.__path__ = []
+    fake_ealert = types.ModuleType('modules.ealert')
+    fake_ealert.EAlert = FakeEAlert
+
+    monkeypatch.setitem(sys.modules, 'modules', fake_modules)
+    monkeypatch.setitem(sys.modules, 'modules.ealert', fake_ealert)
+
+    module_path = Path(__file__).resolve().parents[1] / 'honeypots' / 'redishoneypot.py'
+    spec = importlib.util.spec_from_file_location('redishoneypot_under_test', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_redishoneypot(monkeypatch, lines):
+    FakeEAlert.instances = []
+    redishoneypot_module = load_redishoneypot_module(monkeypatch)
+
+    ecfg = {
+        'cfgfile': '/tmp/ews.cfg',
+        'hostname': 'sensor-01',
+        'ip_ext': '198.51.100.20',
+        'ip_int': '10.0.0.5',
+        'uuid': 'sensor-uuid',
+        'test_lines': lines,
+    }
+
+    redishoneypot_module.redishoneypot(ecfg)
+    return FakeEAlert.instances[0], redishoneypot_module
+
+
+def test_command_events_are_mapped_to_ews_alerts(monkeypatch):
+    lines = [
+        {
+            'timestamp': '2026-06-16T16:16:57.417861509Z',
+            'level': 'INFO',
+            'message': 'connect',
+            'event': 'connect',
+            'protocol': 'redis',
+            'network': 'tcp',
+            'profile': 'legacy6',
+            'session_id': 'session-1',
+            'client_id': 3,
+            'src_ip': '172.22.0.1',
+            'src_port': 59444,
+            'dest_ip': '172.22.0.2',
+            'dest_port': 6379,
+            'session_start': '2026-06-16T16:16:57.417699135Z',
+        },
+        {
+            'timestamp': '2026-06-16T16:16:57.418392675Z',
+            'level': 'INFO',
+            'message': 'command',
+            'event': 'command',
+            'protocol': 'redis',
+            'network': 'tcp',
+            'profile': 'legacy6',
+            'session_id': 'session-1',
+            'client_id': 3,
+            'src_ip': '172.22.0.1',
+            'src_port': 59444,
+            'dest_ip': '172.22.0.2',
+            'dest_port': 6379,
+            'session_start': '2026-06-16T16:16:57.417699135Z',
+            'session_duration': 0.000688832,
+            'session_duration_ms': 0,
+            'client_library_name': 'container-smoketest',
+            'user_agent': 'container-smoketest',
+            'redis_db': 0,
+            'command': 'SET',
+            'command_category': 'write',
+            'arg_count': 2,
+            'response_class': 'simple_string',
+            'response_bytes': 5,
+            'outcome': 'success',
+            'close_after_command': False,
+            'args_text': 'smoke-key smoke-value',
+            'args_truncated': False,
+            'args_sha256': '3893be80bc0b2d59314d66faf0b5b80fdfc42eb5e2efa214897d815d2f4a461f',
+            'analysis_hint': 'redis_set',
+            'key': 'smoke-key',
+            'key_count': 1,
+            'value_size': 11,
+            'value_sha256': '656bacf87e249e74405c09eb79525f3a2a05207aadbbf1c9d04e5a62ca2edff8',
+        },
+        {
+            'timestamp': '2026-06-16T16:16:57.419122382Z',
+            'level': 'INFO',
+            'message': 'close',
+            'event': 'close',
+            'protocol': 'redis',
+            'network': 'tcp',
+            'profile': 'legacy6',
+            'session_id': 'session-1',
+            'client_id': 3,
+            'src_ip': '172.22.0.1',
+            'src_port': 59444,
+            'dest_ip': '172.22.0.2',
+            'dest_port': 6379,
+            'session_end': '2026-06-16T16:16:57.419120882Z',
+        },
+    ]
+
+    fake_alert, redishoneypot_module = run_redishoneypot(monkeypatch, lines)
+
+    assert fake_alert.finished is True
+    assert len(fake_alert.alerts) == 1
+
+    alert = fake_alert.alerts[0]
+    assert alert['data'] == {
+        'analyzer_id': 'redishoneypot-test',
+        'timestamp': '2026-06-16 16:16:57',
+        'timezone': redishoneypot_module.time.strftime('%z'),
+        'source_address': '172.22.0.1',
+        'target_address': '172.22.0.2',
+        'source_port': '59444',
+        'target_port': '6379',
+        'source_protocol': 'tcp',
+        'target_protocol': 'tcp',
+    }
+    assert alert['request'] == {
+        'description': 'Redis Honeypot',
+        'request': 'SET smoke-key smoke-value',
+    }
+    assert alert['additionaldata']['session_id'] == 'session-1'
+    assert alert['additionaldata']['client_id'] == 3
+    assert alert['additionaldata']['session_start'] == '2026-06-16T16:16:57.417699135Z'
+    assert alert['additionaldata']['session_duration'] == 0.000688832
+    assert alert['additionaldata']['session_duration_ms'] == 0
+    assert alert['additionaldata']['protocol'] == 'redis'
+    assert alert['additionaldata']['profile'] == 'legacy6'
+    assert alert['additionaldata']['client_library_name'] == 'container-smoketest'
+    assert alert['additionaldata']['user_agent'] == 'container-smoketest'
+    assert alert['additionaldata']['redis_db'] == 0
+    assert alert['additionaldata']['command'] == 'SET'
+    assert alert['additionaldata']['command_category'] == 'write'
+    assert alert['additionaldata']['arg_count'] == 2
+    assert alert['additionaldata']['response_class'] == 'simple_string'
+    assert alert['additionaldata']['response_bytes'] == 5
+    assert alert['additionaldata']['outcome'] == 'success'
+    assert alert['additionaldata']['close_after_command'] is False
+    assert alert['additionaldata']['args_text'] == 'smoke-key smoke-value'
+    assert alert['additionaldata']['args_truncated'] is False
+    assert alert['additionaldata']['args_sha256'] == '3893be80bc0b2d59314d66faf0b5b80fdfc42eb5e2efa214897d815d2f4a461f'
+    assert alert['additionaldata']['analysis_hint'] == 'redis_set'
+    assert alert['additionaldata']['key'] == 'smoke-key'
+    assert alert['additionaldata']['key_count'] == 1
+    assert alert['additionaldata']['value_size'] == 11
+    assert alert['additionaldata']['value_sha256'] == '656bacf87e249e74405c09eb79525f3a2a05207aadbbf1c9d04e5a62ca2edff8'
+    assert alert['additionaldata']['hostname'] == 'sensor-01'
+    assert 'event' not in alert['additionaldata']
+    assert 'timestamp' not in alert['additionaldata']
+    assert 'src_ip' not in alert['additionaldata']
+    assert 'dest_ip' not in alert['additionaldata']
+
+
+def test_command_event_uses_target_defaults_and_skips_malformed(monkeypatch):
+    lines = [
+        {
+            'timestamp': 'not-a-date',
+            'event': 'command',
+            'src_ip': '203.0.113.10',
+            'command': 'PING',
+        },
+        {
+            'timestamp': '2026-06-16T16:16:57Z',
+            'event': 'command',
+            'network': 'tcp',
+            'src_ip': '203.0.113.10',
+            'src_port': 50000,
+            'command': 'CONFIG',
+            'args_text': 'SET dir /tmp',
+            'command_category': 'recon',
+            'args_sha256': '97751ec7a771e38d3371e6b92520ce3782bb6905ef9a106ba6efc35aa3e060f4',
+            'analysis_hint': 'redis_write_file_attempt',
+            'config_key': 'dir',
+            'config_value': '/tmp',
+        },
+        {
+            'timestamp': '2026-06-16T16:16:57Z',
+            'event': 'command',
+            'src_ip': '203.0.113.11',
+            'command': 'GET',
+        },
+    ]
+
+    fake_alert, _ = run_redishoneypot(monkeypatch, lines)
+
+    assert len(fake_alert.alerts) == 1
+    alert = fake_alert.alerts[0]
+    assert alert['data']['target_address'] == '198.51.100.20'
+    assert alert['data']['target_port'] == '6379'
+    assert alert['request']['request'] == 'CONFIG SET dir /tmp'
+    assert alert['additionaldata']['command_category'] == 'recon'
+    assert alert['additionaldata']['args_sha256'] == '97751ec7a771e38d3371e6b92520ce3782bb6905ef9a106ba6efc35aa3e060f4'
+    assert alert['additionaldata']['analysis_hint'] == 'redis_write_file_attempt'
+    assert alert['additionaldata']['config_key'] == 'dir'
+    assert alert['additionaldata']['config_value'] == '/tmp'


### PR DESCRIPTION
@trixam @elivlo : Please review and test

Adapt redishoneypot integration to the RedisHoneyPot next branch JSONL log format: https://github.com/t3chn0m4g3/RedisHoneyPot/tree/next

- parse command events using timestamp/src/dest/network fields
- preserve Redis command/session metadata as AdditionalData
- keep EWS core field mapping and existing config unchanged
- add focused parser tests for sample-style next branch logs

Sample logs:
```jsonl
{"timestamp":"2026-06-16T16:16:57.417861509Z","level":"INFO","message":"connect","event":"connect","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.000156,"session_duration_ms":0,"client_library_name":"container-smoketest","user_agent":"container-smoketest"}
{"timestamp":"2026-06-16T16:16:57.417938009Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.000234041,"session_duration_ms":0,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"CLIENT","command_category":"recon","arg_count":3,"response_class":"simple_string","response_bytes":5,"outcome":"success","close_after_command":false,"args_text":"SETINFO LIB-NAME container-smoketest","args_truncated":false,"args_sha256":"7adfa79651e84be2c0488a2d8b4424f60a3251b3accd36260571151d30815e44","analysis_hint":"redis_client","client_subcommand":"setinfo"}
{"timestamp":"2026-06-16T16:16:57.418024717Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.000322625,"session_duration_ms":0,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"PING","command_category":"session","arg_count":0,"response_class":"simple_string","response_bytes":7,"outcome":"success","close_after_command":false}
{"timestamp":"2026-06-16T16:16:57.418392675Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.000688832,"session_duration_ms":0,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"SET","command_category":"write","arg_count":2,"response_class":"simple_string","response_bytes":5,"outcome":"success","close_after_command":false,"args_text":"smoke-key smoke-value","args_truncated":false,"args_sha256":"3893be80bc0b2d59314d66faf0b5b80fdfc42eb5e2efa214897d815d2f4a461f","analysis_hint":"redis_set","key":"smoke-key","key_count":1,"value_size":11,"value_sha256":"656bacf87e249e74405c09eb79525f3a2a05207aadbbf1c9d04e5a62ca2edff8"}
{"timestamp":"2026-06-16T16:16:57.41855605Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.000854707,"session_duration_ms":0,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"GET","command_category":"read","arg_count":1,"response_class":"bulk_string","response_bytes":18,"outcome":"success","close_after_command":false,"args_text":"smoke-key","args_truncated":false,"args_sha256":"c1e9511acb17ae357da9e3f21b8caa079a0c4eb2add8f148c69bb2ec42cded93","analysis_hint":"redis_get","key":"smoke-key","key_count":1}
{"timestamp":"2026-06-16T16:16:57.418856882Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.001154498,"session_duration_ms":1,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"CONFIG","command_category":"recon","arg_count":3,"response_class":"simple_string","response_bytes":5,"outcome":"success","close_after_command":false,"args_text":"SET dir /tmp","args_truncated":false,"args_sha256":"97751ec7a771e38d3371e6b92520ce3782bb6905ef9a106ba6efc35aa3e060f4","analysis_hint":"redis_write_file_attempt","config_subcommand":"set","config_key":"dir","config_value":"/tmp","config_value_truncated":false,"config_value_sha256":"e9671acd244849c57167c658fa2f969752048f7ab184a3dcf5c46cb4d56ae124"}
{"timestamp":"2026-06-16T16:16:57.418967591Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.00126679,"session_duration_ms":1,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"SAVE","command_category":"unknown","arg_count":0,"response_class":"simple_string","response_bytes":5,"outcome":"success","close_after_command":false}
{"timestamp":"2026-06-16T16:16:57.419043715Z","level":"INFO","message":"command","event":"command","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.001343498,"session_duration_ms":1,"client_library_name":"container-smoketest","user_agent":"container-smoketest","redis_db":0,"command":"QUIT","command_category":"session","arg_count":0,"response_class":"simple_string","response_bytes":5,"outcome":"success","close_after_command":true}
{"timestamp":"2026-06-16T16:16:57.419122382Z","level":"INFO","message":"close","event":"close","protocol":"redis","network":"tcp","profile":"legacy6","session_id":"0d25cd5e6d652b7a1bd4739e4d9ebefc","client_id":3,"src_ip":"172.22.0.1","src_port":59444,"dest_ip":"172.22.0.2","dest_port":6379,"session_start":"2026-06-16T16:16:57.417699135Z","session_duration":0.001421748,"session_duration_ms":1,"session_end":"2026-06-16T16:16:57.419120882Z","client_library_name":"container-smoketest","user_agent":"container-smoketest"}

```